### PR TITLE
Add slash to ls command for directory

### DIFF
--- a/kernel/terminal.cpp
+++ b/kernel/terminal.cpp
@@ -268,6 +268,9 @@ void ListAllEntries(Terminal* term, uint32_t dir_cluster) {
       char name[13];
       fat::FormatName(dir[i], name);
       term->Print(name);
+      if (dir[i].attr == fat::Attribute::kDirectory) {
+        term->Print("/");
+      }
       term->Print("\n");
     }
 


### PR DESCRIPTION
lsコマンドでディレクトリとファイルを区別するために、ディレクトリの場合は末尾にスラッシュを表示するようにした。